### PR TITLE
Refactor: Rename dqm-ml-v2 to dqm-ml, fix security vulnerabilities, a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install individual packages based on your needs:
 | **dqm-ml-images** | Visual feature extraction from images | [![][pypi-images-badge]](https://pypi.org/project/dqm-ml-images/) |
 | **dqm-ml-pytorch** | PyTorch-based metrics (Domain Gap) | [![][pypi-pytorch-badge]](https://pypi.org/project/dqm-ml-pytorch/) |
 
-> **Note:** The `dqm-ml-v2` package is the CLI wrapper, not yet delivered as a package. For now, install individual packages above or use the full workspace.
+> **Note:** The `dqm-ml` package is the CLI wrapper.
 
 [pypi-core-badge]: https://img.shields.io/pypi/v/dqm-ml-core.svg
 [pypi-pipeline-badge]: https://img.shields.io/pypi/v/dqm-ml-job.svg
@@ -88,6 +88,7 @@ Think of it as a **health check for your data** — DQM-ML checks your dataset's
 We've all heard the saying "garbage in, garbage out." But how do you *measure* if your data is any good? That's exactly what DQM-ML helps you answer.
 
 Poor data quality can lead to:
+
 - **Biased models** that don't generalize well
 - **Unexpected failures** in production
 - **Wasted resources** training on bad data
@@ -130,18 +131,16 @@ In the current version, the available (or to be available) metrics are:
 
 # Installation
 
-Install the DQM-ML V2 framework with all available metrics and helpers using pip:
-> :warning: **NOT YET AVAILABLE**, ONLY ON v2.0.0 but all functionality are available with detail install bellow
+Install the DQM-ML framework with all available metrics and helpers using pip:
 
 ```bash
-pip install "dqm-ml-v2[all]" 
+pip install "dqm-ml[all]" 
 ```
 
-Install the DQM-ML V2 framework by passing only needed optional dependency:
-> :warning: **NOT YET AVAILABLE**, ONLY ON v2.0.0 but all functionality are available with detail install bellow
+Install the DQM-ML framework by passing only needed optional dependency:
 
 ```bash
-pip install "dqm-ml-v2[notebooks, pytorch, job, images ]" 
+pip install "dqm-ml[notebooks, pytorch, job, images]" 
 ```
 
 Manually install all packages:

--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,8 @@ This file tracks planned improvements, bug fixes, and refactoring tasks for the 
 
 * [x] Improve test management in `noxfile.py`.
 * [x] Finalize Autodoc configuration in `mkdocs.yml`.
-* [ ] Mark original repository as deprecated and reference this one.
-* [ ] Set version to V2.0.0 upon completion of core migration.
+* [x] Mark original repository as deprecated and reference this one. (Legacy dqm-ml submodule removed, now using dqm-ml as main CLI)
+* [X] Set version to V2.0.0-rc upon completion of core migration. (CLI renamed from dqm-ml-v2 to dqm-ml)
 * [ ] Choose between `pyyaml` and `ruamel.yaml` to standardize dependency.
 
 ## Core API (`dqm-ml-core`)
@@ -49,7 +49,7 @@ This file tracks planned improvements, bug fixes, and refactoring tasks for the 
 * [ ] Fix type-checking errors in `image_embedding.py` and `domain_gap.py` (e.g., `vec` function).
 * [ ] Improve configuration and available metrics check in `domain_gap.py`.
 * [ ] Add proper error return codes to the Domain Gap API.
-* [ ] Re-implement missing V1 Domain Gap metrics: PAD, CMD.
+* [ ] Re-implement missing V1 metrics: Gini-Simpson, Simpson indices, Relative Diversity, PAD, CMD.
 * [ ] Investigate result variations between V1 and V2 for KLMVN and FID metrics.
 
 ### New Domains
@@ -76,7 +76,7 @@ This file tracks planned improvements, bug fixes, and refactoring tasks for the 
 
 ## Scientific & Community
 
-* [ ] Re-implement the Diversity metric (pending scientific discussion on target content and entropy position).
+* [ ] Re-implement the Diversity metric (pending scientific discussion on target content and entropy position). See ROADMAP for full V1 metrics list.
 * [ ] Rationalize the level of parametrization across all metrics.
 * [ ] Scientific committee review: allocation of methods between Diversity and Representativeness.
 * [ ] Expand supported reference distributions for Representativeness to reflect real-world data.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,10 +18,11 @@ V2 represents a major architectural improvement, but it's still evolving. Here's
 | Area | Current State | Notes |
 |------|---------------|-------|
 | **Beta packages** | `dqm-ml-job`, `dqm-ml-images` | Config schemas may change based on feedback |
-| **V1 metrics** | Some not yet ported | Gini-Simpson, Simpson indices, Relative Diversity, PAD, CMD |
+| **V1 metrics** | Some not yet ported | Gini-Simpson, Simpson indices, Relative Diversity, PAD, CMD, Diversity (pending scientific discussion) |
 | **Result variations** | Minor differences in FID/KLMVN | Being investigated for mathematical equivalence |
 | **Single-column focus** | Most metrics work per-column | Multi-dimensional feature support coming |
-| **Legacy dependency** | Submodule still present | Legacy `dqm-ml` for comparison (to be phased out) |
+~~| Legacy dependency | Submodule still present | Legacy `dqm-ml` for comparison (to be phased out) |~~
+
 
 > 📝 **Your feedback matters!** If you encounter issues or have suggestions, please [open an issue](https://github.com/Safenai/dqm-ml-workspace/issues).
 
@@ -29,15 +30,27 @@ V2 represents a major architectural improvement, but it's still evolving. Here's
 
 Here's our vision for DQM-ML, organized into phases:
 
+### Phase 1: Complete V2.0.0-rc (Now - open for comment dqm-ml v2)
+
+Usable version of dqm-ml v2 open for comment before official release.
+- [x] **Standalone release** - Finalize V2.0.0 as a proper package
+
 ### Phase 1: Complete V2.0.0 (Near term)
 
 What's coming in the next release:
 
 - [ ] **Feature parity** - Port remaining V1 metrics to V2 API
 - [ ] **API freeze** - Lock down `dqm-ml-core` for stability
-- [ ] **Standalone release** - Finalize V2.0.0 as a proper package
 
-### Phase 2: Performance & Scale (Mid term)
+### Phase 2: New Domains 
+
+Expanding what DQM-ML can analyze:
+
+- [ ] **Time series** - New package for sequential data quality
+- [ ] **Multi-modal** - Support for text + image datasets
+- [ ] **SQL integration** - Compute metrics directly via DuckDB
+
+### Phase 3: Performance & Scale 
 
 Improving for larger workloads:
 
@@ -45,13 +58,7 @@ Improving for larger workloads:
 - [ ] **Parallelization** - Multi-core processing for image features and deep learning metrics
 - [ ] **Database support** - Read directly from databases, not just files
 
-### Phase 3: New Domains (Long term)
 
-Expanding what DQM-ML can analyze:
-
-- [ ] **Time series** - New package for sequential data quality
-- [ ] **Multi-modal** - Support for text + image datasets
-- [ ] **SQL integration** - Compute metrics directly via DuckDB
 
 ## How We Prioritize
 
@@ -96,7 +103,8 @@ Looking to contribute? Here's what needs help most:
 
 | Version | Release Date | Highlights |
 |---------|-------------|------------|
-| 1.1.x | Current | V2 architecture, streaming, plugins |
+| 2.0.0-rc | 2026 | V2 architecture, streaming, plugins, `dqm-ml` CLI (renamed from dqm-ml-v2) |
+| 1.1.x | Q1 2026 | V2 release candidate series |
 | 1.0.x | Earlier | Original library (V1) |
 
-The original `dqm-ml` package is still available as a submodule for comparison, but new development uses the V2 API.
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -219,6 +219,182 @@ def compute(self, batch_metrics: dict | None = None) -> dict[str, pa.Array]:
     # Your code here
 ```
 
+## Testing Strategy
+
+This section describes how tests are organized in DQM-ML and how to add new tests.
+
+### Test Organization
+
+```mermaid
+flowchart TB
+    subgraph "Test Types"
+        direction TB
+        U[Unit Tests<br/>tests/unit/]
+        I[Integration Tests<br/>tests/integration/]
+        C[CLI Tests<br/>tests/cli/]
+    end
+    
+    subgraph "Test Pyramid"
+        TP[Unit Tests - Fast, isolated<br/>Core logic, processors]
+        TI[Integration Tests - Real data<br/>Pipelines, loaders, metrics]
+        TC[CLI Tests - End-to-end<br/>Commands, config files]
+    end
+    
+    U --> TP
+    I --> TI
+    C --> TC
+    
+    F[Fixtures - Shared test data<br/>tests/integration/fixtures/]
+    TP --> F
+    TI --> F
+end
+```
+
+### Test Directory Structure
+
+```
+tests/
+├── conftest.py              # Pytest configuration & fixture imports
+├── utils/                   # Utility functions for tests
+│   ├── files.py            # File handling helpers
+│   ├── jobs.py             # Job configuration helpers
+│   └── plots.py            # Visualization helpers
+├── unit/                    # Unit tests (fast, isolated)
+│   ├── core/               # Core API tests (data_processor, metric_runner)
+│   ├── pipeline/           # Pipeline tests (loaders, writers)
+│   └── v2/                 # CLI wrapper tests
+├── integration/             # Integration tests (real data, slow)
+│   ├── fixtures/           # Test fixtures and data
+│   │   ├── config.py      # Configuration fixtures
+│   │   ├── data.py        # Data fixtures (synthetic + real)
+│   │   ├── jobs.py        # Job configuration fixtures
+│   │   └── paths.py       # Path fixtures
+│   ├── test_completeness.py
+│   ├── test_representativeness.py
+│   ├── test_domain_gap.py
+│   ├── test_visual_features.py
+│   └── test_pandas_welding.py
+└── cli/                     # CLI end-to-end tests
+    ├── test_v2_wrapper.py
+    └── test_job_cli.py
+```
+
+### Test Fixtures
+
+DQM-ML uses pytest fixtures for reusable test data. Here's what's available:
+
+| Fixture | Scope | Purpose | Usage |
+|---------|-------|---------|-------|
+| `test_path` | session | Tests directory path | All test files |
+| `output_path` | session | Output directory for test results | Integration tests |
+| `coco_data` | session | COCO dataset for domain gap tests | `test_domain_gap.py` |
+| `normal_dist` | function | Normal distribution sample | Representativeness tests |
+| `not_normal_dist` | function | Non-normal distribution | Statistical tests |
+| `uniform_dist` | function | Uniform distribution | Statistical tests |
+| `not_uniform_dist` | function | Non-uniform distribution | Statistical tests |
+| `job_completeness` | function | Completeness job config | Pipeline tests |
+| `job_representativeness` | function | Representativeness job config | Pipeline tests |
+| `job_domain_gap` | function | Domain gap job config | Pipeline tests |
+| `job_visual_features` | function | Visual features job config | Pipeline tests |
+
+**Example using fixtures**:
+
+```python
+import pytest
+
+def test_completeness_with_data(
+    test_path: str,
+    uniform_dist: Any
+) -> None:
+    """Test completeness metric with uniform distribution."""
+    processor = CompletenessProcessor(
+        name="test",
+        config={"input_columns": ["feature"]}
+    )
+    result = processor.compute({})
+    assert result is not None
+```
+
+### Running Tests
+
+```bash
+# All tests with coverage report
+uv run nox -s test
+
+# Fast mode (skip slow tests)
+uv run pytest -m "not slow"
+
+# Specific test file
+uv run pytest tests/integration/test_completeness.py
+
+# With verbose output
+uv run pytest -v tests/
+
+# Run only unit tests
+uv run pytest tests/unit/
+
+# Run with coverage for specific package
+uv run pytest --cov=packages/dqm-ml-core tests/
+```
+
+### Adding a New Test
+
+1. **Choose test type**:
+   - **Unit tests**: `tests/unit/package_name/` - for fast, isolated tests
+   - **Integration tests**: `tests/integration/` - for real data and pipeline tests
+   - **CLI tests**: `tests/cli/` - for end-to-end command testing
+
+2. **Follow naming conventions**:
+   - Test files: `test_*.py`
+   - Test functions: `test_*`
+   - Use descriptive names: `test_completeness_returns_valid_score`
+
+3. **Use existing fixtures**:
+   ```python
+   def test_my_feature(test_path: str, uniform_dist: Any) -> None:
+       # Your test code using fixtures
+       pass
+   ```
+
+4. **Mark slow tests** (if your test takes >30s):
+   ```python
+   @pytest.mark.slow
+   def test_slow_operation() -> None:
+       # This test will be skipped with -m "not slow"
+       pass
+   ```
+
+### Test Data Sources
+
+| Type | Source | When to Use |
+|------|--------|--------------|
+| **Synthetic** | Generated via fixtures (normal_dist, uniform_dist) | Most unit/integration tests |
+| **Real datasets** | COCO-2017 via `fiftyone.zoo` | Domain gap tests |
+| **Example data** | `examples/config/` | CLI tests |
+
+### Test Coverage & Results
+
+After running tests, reports are generated:
+
+| Report | Location | Description |
+|--------|----------|-------------|
+| Coverage HTML | `docs/reports/htmlcov/index.html` | Line-by-line coverage |
+| Test Results HTML | `docs/reports/pytest/pytest_report.html` | Test execution report |
+| Live Coverage | [GitHub Pages](https://safenai.github.io/dqm-ml-workspace/reports/htmlcov/) | Published coverage |
+
+> **Tip**: Build the docs to generate these reports: `uv run nox -s docs_offline`
+
+### CI/CD Testing
+
+Tests run automatically on every push via GitHub Actions:
+
+- **Lint**: Code style with ruff
+- **Type Check**: Type safety with mypy
+- **Test**: Full test suite with pytest
+- **Docs**: Documentation build
+
+See the [README](../index.md) for current status badges.
+
 ## Getting Help
 
 - 📖 Check the [Documentation](https://safenai.github.io/dqm-ml-workspace/) - Start here!

--- a/docs/dqm-ml-overview.md
+++ b/docs/dqm-ml-overview.md
@@ -15,7 +15,7 @@ dqm-ml-workspace/
 │   ├── dqm-ml-job/           # Pipeline orchestration & data loaders
 │   ├── dqm-ml-images/        # Image feature extraction
 │   ├── dqm-ml-pytorch/       # PyTorch-based metrics (Domain Gap)
-│   └── dqm-ml-v2/            # CLI wrapper & entry point
+│   └── dqm-ml/            # CLI wrapper & entry point
 ├── tests/                    # Test suite
 ├── docs/                     # Documentation
 └── examples/                 # Example configurations
@@ -25,9 +25,9 @@ Here's how the packages relate to each other:
 
 ```mermaid
 flowchart TB
-    core[dqm-ml-core<br/>Core API] --> job[dqm-ml-job<br/>Orchestration]
-    core --> images[dqm-ml-images<br/>Visual Features]
-    core --> pytorch[dqm-ml-pytorch<br/>PyTorch Metrics]
+    job[dqm-ml-job<br/>Orchestration] --> core[dqm-ml-core<br/>Core API]
+    images[dqm-ml-images<br/>Visual Features] --> core
+    pytorch[dqm-ml-pytorch<br/>PyTorch Metrics] --> core
     cli[dqm-ml<br/>CLI Wrapper] --> job
     cli --> core
     cli --> images

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -43,7 +43,7 @@ def copy_package_readmes():
         "dqm-ml-job",
         "dqm-ml-images",
         "dqm-ml-pytorch",
-        "dqm-ml-v2",
+        "dqm-ml",
     ]
 
     for pkg in packages_to_copy:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,8 +12,24 @@ pip install dqm-ml-core
 pip install dqm-ml-core dqm-ml-job dqm-ml-images dqm-ml-pytorch
 
 # Or install the CLI wrapper
-pip install dqm-ml-v2
+pip install dqm-ml
 ```
+
+## Large Files (Git LFS)
+
+Some test datasets are stored with Git LFS. If you're running tests or working with large datasets:
+
+```bash
+# Install git-lfs
+sudo apt-get install git-lfs  # Linux
+brew install git-lfs          # macOS
+
+# Pull large files
+git lfs pull
+```
+
+> **Note**: This is mainly needed for development and testing. CI/CD handles this automatically.
+> For most users installing via pip, no additional setup is required.
 
 ## Using the CLI
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,7 +154,7 @@ nav:
       - PyTorch: packages/dqm-ml-pytorch.md
       - CLI: packages/dqm-ml.md
     - Test Reports:
-      - Pytest report: reports/pytest/pytest_report.html
-      - Coverage Report: reports/htmlcov/coverage_report.html
+      - Results: reports/pytest/pytest_report.html
+      - Coverage: reports/htmlcov/coverage_report.html
       - Performance Report: TBD2.md
 

--- a/packages/dqm-ml-job/requirements.txt
+++ b/packages/dqm-ml-job/requirements.txt
@@ -1,2 +1,3 @@
 dqm-ml-core>=0.0.1
 pyyaml>=6.0
+tqdm>=4.65.0

--- a/packages/dqm-ml/README.md
+++ b/packages/dqm-ml/README.md
@@ -1,19 +1,19 @@
-# DQM-ML V2 CLI Wrapper
+# DQM-ML CLI Wrapper
 
-Main CLI entry point for DQM-ML V2. Consolidates all modular packages into a single command-line interface.
+Main CLI entry point for DQM-ML. Consolidates all modular packages into a single command-line interface.
 
 ## Installation
 
 ```bash
 # Basic installation (core only)
-pip install dqm-ml-v2
+pip install dqm-ml
 
 # Installation with optional components
-pip install "dqm-ml-v2[all]"      # Everything
-pip install "dqm-ml-v2[pipeline]" # core + job
-pip install "dqm-ml-v2[pytorch]"  # core + pytorch
-pip install "dqm-ml-v2[images]"   # core + images
-pip install "dqm-ml-v2[notebooks]" # Jupyter support
+pip install "dqm-ml[all]"      # Everything
+pip install "dqm-ml[job]"      # core + job
+pip install "dqm-ml[pytorch]" # core + pytorch
+pip install "dqm-ml[images]"  # core + images
+pip install "dqm-ml[notebooks]" # Jupyter support
 ```
 
 ## Quick Start


### PR DESCRIPTION
…nd improve docs

- Rename dqm-ml-v2 package to dqm-ml (CLI entry point)
- Remove legacy dqm-ml submodule reference
- Fix 10 security vulnerabilities by upgrading dependencies:
  - strawberry-graphql: 0.287.3 -> 0.314.3
  - tornado: 6.5.4 -> 6.5.5
  - cryptography: 46.0.4 -> 46.0.7
  - requests, pygments: updated
- Add tqdm dependency to dqm-ml-job
- Pin mkdocs-jupyter<0.26 to fix api-autonav compatibility
- Sync TODO.md and ROADMAP.md (V1 metrics, legacy deprecation)
- Fix mermaid diagram (correct core->job dependency direction)
- Add test strategy documentation in contributing.md
- Add Git LFS section to quickstart.md
- Update docs references from dqm-ml-v2 to dqm-ml

# Describe your changes

## Screenshots (if appropriate)

## Issue ticket number and link

## New tests added

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I All tests pass
- [x] I have checked that Black, Flake8, Prettier and Cspell are passing