### PR TITLE
RC1 - fix dependency of all package >=rc0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ In the current version, the available metrics are:
 Install the DQM-ML framework with all available metrics and helpers using pip:
 
 ```bash
-pip install "dqm-ml[all]>=2.0.0rc1" 
+pip install --pre "dqm-ml[all]" 
 ```
 
 Install the DQM-ML framework by passing only needed optional dependency:
 
 ```bash
-pip install "dqm-ml[notebooks, pytorch, job, images]>=2.0.0rc1" 
+pip install --pre "dqm-ml[notebooks, pytorch, job, images]" 
 ```
 
 Manually install all packages:

--- a/README.md
+++ b/README.md
@@ -139,16 +139,19 @@ In the current version, the available metrics are:
 
 # Installation
 
+> [!IMPORTANT]
+> This current version is in release candidate so you might explicitly install version >=2.0.0rc1, installing without defining version will install legacy dqm-ml
+
 Install the DQM-ML framework with all available metrics and helpers using pip:
 
 ```bash
-pip install "dqm-ml[all]" 
+pip install "dqm-ml[all]>=2.0.0rc1" 
 ```
 
 Install the DQM-ML framework by passing only needed optional dependency:
 
 ```bash
-pip install "dqm-ml[notebooks, pytorch, job, images]" 
+pip install "dqm-ml[notebooks, pytorch, job, images]>=2.0.0rc1" 
 ```
 
 Manually install all packages:

--- a/packages/dqm-ml-core/requirements.txt
+++ b/packages/dqm-ml-core/requirements.txt
@@ -1,3 +1,4 @@
+typing-extensions>=4.15.0
 pyarrow>=6.0.0
 numpy>=1.20.0
 pandas>=1.3.0

--- a/packages/dqm-ml-images/requirements.txt
+++ b/packages/dqm-ml-images/requirements.txt
@@ -1,3 +1,3 @@
-dqm-ml-core>=0.0.1
+dqm-ml-core>=2.0.0rc0
 pillow>=12.1.1
 scipy>=1.7.0

--- a/packages/dqm-ml-job/requirements.txt
+++ b/packages/dqm-ml-job/requirements.txt
@@ -1,3 +1,3 @@
-dqm-ml-core>=0.0.1
+dqm-ml-core>=2.0.0rc0
 pyyaml>=6.0
 tqdm>=4.65.0

--- a/packages/dqm-ml-pytorch/requirements.txt
+++ b/packages/dqm-ml-pytorch/requirements.txt
@@ -1,3 +1,4 @@
+dqm-ml-core>=2.0.0rc0
 torch>=2.0.0
 torchvision>=0.15.0
-pyarrow>=6.0.0
+

--- a/packages/dqm-ml/pyproject.toml
+++ b/packages/dqm-ml/pyproject.toml
@@ -31,13 +31,13 @@ notebooks = [
     "plotly>=5.0.0",
 ]
 
-job = [ "dqm-ml-job>=1.1.4"]
-pytorch = [ "dqm-ml-images>=1.1.4"]
-images = [ "dqm-ml-images>=1.1.4"]
+job = [ "dqm-ml-job>=2.0.0rc0"]
+pytorch = [ "dqm-ml-images>=2.0.0rc0"]
+images = [ "dqm-ml-images>=2.0.0rc0"]
 
-# all = [
-#     "dqm-ml[notebooks, job, pytorch, images]",
-# ]
+all = [
+     "dqm-ml[notebooks, job, pytorch, images]",
+ ]
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,13 @@
 [project]
 name = "dqm-workspace"
-version = "1.1.4"
+dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "dqm-ml>=1.1.4",
-    "dqm-ml-core",
-    "dqm-ml-images",
-    "dqm-ml-job",
-    # "dqm-ml[pipeline]",
-    "dqm-ml-pytorch",
+    "dqm-ml>=2.0.0rc0",
+    "dqm-ml-core>=2.0.0rc0",
+    "dqm-ml-images>=2.0.0rc0",
+    "dqm-ml-job>=2.0.0rc0",
+    "dqm-ml-pytorch>=2.0.0rc0",
     "pre-commit>=4.5.0",
     "pycocotools>=2.0.10",
     "ruamel-yaml>=0.19.1",
@@ -21,8 +20,9 @@ Documentation = "https://safenai.github.io/dqm-ml-workspace"
 Repository = "https://github.com/Safenai/dqm-ml-workspace"
 
 [build-system]
-requires = ["uv_build>=0.8.0,<0.9.0"]
-build-backend = "uv_build"
+requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+build-backend = "setuptools.build_meta"
+
 
 # UV Configuration workspace
 # - dependency groups, repository packages to includes, etc.
@@ -31,7 +31,6 @@ dqm-ml-core = { workspace = true }
 dqm-ml-job = { workspace = true }
 dqm-ml-images = { workspace = true }
 dqm-ml-pytorch = { workspace = true }
-# dqm-ml = { workspace = true }
 dqm-ml = { workspace = true }
 
 [tool.uv]
@@ -196,3 +195,6 @@ exclude_also = [
 
 [tool.cspell]
 files = ["**/*"]
+
+[tool.setuptools_scm]
+version_file = "src/dqm_ml_workspace/_version_.py"

--- a/uv.lock
+++ b/uv.lock
@@ -1421,7 +1421,6 @@ requires-dist = [
 
 [[package]]
 name = "dqm-workspace"
-version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "dqm-ml" },

--- a/uv.lock
+++ b/uv.lock
@@ -1317,6 +1317,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "dqm-ml-images" },
+    { name = "dqm-ml-job" },
+    { name = "jupyter" },
+    { name = "plotly" },
+]
 images = [
     { name = "dqm-ml-images" },
 ]
@@ -1333,6 +1339,7 @@ pytorch = [
 
 [package.metadata]
 requires-dist = [
+    { name = "dqm-ml", extras = ["images", "job", "notebooks", "pytorch"], marker = "extra == 'all'", editable = "packages/dqm-ml" },
     { name = "dqm-ml-core", editable = "packages/dqm-ml-core" },
     { name = "dqm-ml-images", marker = "extra == 'images'", editable = "packages/dqm-ml-images" },
     { name = "dqm-ml-images", marker = "extra == 'pytorch'", editable = "packages/dqm-ml-images" },
@@ -1340,7 +1347,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'notebooks'", specifier = ">=1.0.0" },
     { name = "plotly", marker = "extra == 'notebooks'", specifier = ">=5.0.0" },
 ]
-provides-extras = ["notebooks", "job", "pytorch", "images"]
+provides-extras = ["notebooks", "job", "pytorch", "images", "all"]
 
 [[package]]
 name = "dqm-ml-core"


### PR DESCRIPTION
fix following availability of rc0 in pypi : 
- update readme to add --pre option for install during release candidate phase
- fix the minimal dependency of all the package to >=2.0..0rc0
- add typing-extensions to dqm-ml-core 
- make dynamic version for workspace (not available in pypi)