### PR TITLE
docs: add release notes infrastructure and fix mkdocs site issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,32 @@ jobs:
             echo "is_on_main=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # TEMPORARY, remove before final release
+  check-dev:
+    runs-on: ubuntu-24.04
+    outputs:
+      is_on_dev: ${{ steps.check.outputs.is_on_dev }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if tag commit is on dev
+        id: check
+        run: |
+          git fetch origin +refs/heads/dev:refs/remotes/origin/dev --depth=1
+          if git merge-base --is-ancestor "${{ github.sha }}" origin/dev; then
+            echo "is_on_dev=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_on_dev=false" >> "$GITHUB_OUTPUT"
+          fi
+
   publish-pypi:
-    needs: check-main
-    if: needs.check-main.outputs.is_on_main == 'true'
+    # TEMPORARY: Switched from check-main to check-dev for testing.
+    # Restore before final release: 
+    # needs: check-main
+    # if: needs.check-main.outputs.is_on_main == 'true'
+    needs: check-dev
+    if: needs.check-dev.outputs.is_on_dev == 'true'
     runs-on: ubuntu-24.04
     environment: release
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ __pycache__
 .venv
 # Pytest report
 **/pytest_report.html
-docs/examples
+
 examples/outputs
 assets
 
@@ -37,6 +37,9 @@ output
 docs/index.md
 docs/AGENTS.md
 docs/packages/
+docs/examples
+docs/RELEASE.md
+docs/CHANGELOG.md
 .github/workflows/tests_act.yml
 
 # Test logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,48 @@
 # Changelog
 
-## 2.0.0 (2026-06-30) — Pipeline DAG, Pydantic configs, example notebooks, and documentation
+## 2.0.0-rc4 (2026-07-17) — ProcessorRunner improvements, package isolation testing, configurable seeds
+
+This release addresses review feedback from 2.0.0-rc3, enhancing ProcessorRunner with direct image-to-domain-gap support, adding package isolation smoke tests, and introducing configurable test seeds.
+
+### ProcessorRunner Enhancements
+
+* `ProcessorRunner.run_gap()` now accepts raw images directly via optional `features` parameter — compute domain gaps from image bytes without manual embedding extraction.
+* New `_df_to_record_batch()` helper for robust DataFrame-to-PyArrow conversion, handling `FixedSizeListArray` for embeddings.
+* Renamed `metrics_processors` parameter to `processors` in `run()` for clarity.
+* Separated `select_columns` intermediate results from final `batch_features` to avoid metric pollution.
+
+### Package Isolation Testing
+
+* New `tests/packaging/` directory with smoke tests for all 5 packages: dqm-ml, dqm-ml-core, dqm-ml-images, dqm-ml-job, dqm-ml-pytorch.
+* Smoke scripts verify imports, basic functionality, and YAML-based execution in isolated virtual environments.
+* New `tests/fixtures/packaging_fixtures.py` with `isolated_venv` and `wheels_dir` fixtures.
+* New `docs/packaging-tests.md` and `docs/testing.md` documentation.
+
+### Configurable Test Seeds
+
+* New `tests/utils/seeds.py` with `get_test_seed()` function reading `DQM_ML_TEST_SEED` env var (default 42).
+* Session-scoped `test_seed` fixture in `tests/conftest.py`.
+* Updated ~35 test files and YAML templates to use configurable seeds instead of hardcoded values.
+* Seeds injected via `tests/utils/jobs.py:generate_job()` for YAML template generation.
+
+### CI Improvements
+
+* tqdm progress bars suppressed in CI via `TQDM_DISABLE=1` in GitHub Actions and GitLab CI.
+* `noxfile.py` now sets `DQM_ML_TEST_SEED=42` in all test sessions.
+* `.mise.toml` exports `DQM_ML_TEST_SEED=42` for local development.
+
+### Documentation
+
+* New `docs/testing.md` with test organization, directory structure, and adding tests guide.
+* New `docs/packaging-tests.md` with package isolation testing documentation.
+* Improved READMEs for dqm-ml-core (+134 lines), dqm-ml-images (+100 lines), dqm-ml-pytorch (+252 lines).
+
+### Bug Fixes
+
+* S3 support fixes in CLI and processor (`dqm_ml_job.cli`, `dqm_ml_job.utils.s3`).
+* CI tag regex and PyPI publish workflow fixes.docs/index.md 
+
+## 2.0.0-rc3 (2026-06-30) — Pipeline DAG, Pydantic configs, example notebooks, and documentation
 
 This release introduces a consistent configuration with Pydantic models and validation, adds a topological processor DAG, example notebooks and a user guide, improves domain-gap algorithms and image embedding, and refactors tests to generate synthetic data inline.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Install individual packages based on your needs:
 * **[Website version](https://safenai.github.io/dqm-ml-workspace/)**
 
 * **[Quick Start](./docs/quickstart.md)**: Get started in 5 minutes.
+* **[Release Notes](./RELEASE.md)**: What's new in the latest version.
 * **[Architecture & Rational](./docs/dqm-ml-v2.md)**: The "why" and "how" of V2.
 * **[Project Overview](./docs/dqm-ml-overview.md)** — Package structure and development conventions
 * **[Metrics Guide](./docs/metrics.md)**: Detailed list of available metrics and their configurations.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,86 @@
+# Release Notes
+
+## v2.0.0 (2026-07-17)
+
+Major release introducing a new processor architecture with three specialized
+interfaces (FeaturesProcessor, MetricsProcessor, GapProcessor), Pydantic-based
+configuration, a processor DAG with topological execution, new domain gap
+algorithms, S3 support, and comprehensive documentation.
+
+### Processor Interfaces
+
+- Split monolithic `DatametricProcessor` into three specialized interfaces:
+  - `FeaturesProcessor` — feature extraction (visual features, embeddings)
+  - `MetricsProcessor` — tabular metrics (completeness, diversity, representativeness)
+  - `GapProcessor` — domain gap analysis (FID, MMD-RBF, Wasserstein-1D)
+- `ProcessorRunner.run_gap()` accepts raw images directly — no manual embedding
+  extraction needed when paired with `ImageEmbeddingProcessor`.
+
+### Configuration
+
+- Pydantic models for processor, output, dataloader, and global configs with
+  validation and type safety.
+- `StorageConfig` model for S3 with retry strategies, role-based access, and
+  env-var fallback.
+
+### Pipeline
+
+- Topological sort ensures generators run before consumers in `DatasetJob.execute()`.
+- Accumulate-then-flush mode for single-path output patterns.
+- Configurable `compute_max_memory` with memory-threshold parsing.
+
+### Metrics
+
+- **Domain Gap**: MMD-RBF, MMD-Poly, PAD, CMD with multi-layer support.
+- **Domain Gap**: KLMVN variance-eps dampening, FID epsilon regularization,
+  PAD with `CalibratedClassifierCV`, CMD multi-channel spatial moments.
+- **Diversity**: New `DiversityProcessor` with Simpson, Gini-Simpson, Shannon,
+  and Richness indices.
+- **Representativeness**: Mean-std estimation, expected-counts method,
+  per-column distribution parameters, path-prefix for sample paths.
+- **Completeness**: Improved validation and error handling.
+
+### Image Processing
+
+- Multi-input-column support for embeddings.
+- Lazy model loading with auto device resolution.
+- Column prefix/suffix and S3 per-column path prefixes.
+- Configurable failure handling with rate thresholds.
+
+### S3 Support
+
+- Shared S3 utility (`dqm_ml_job.utils.s3.get_s3_filesystem`) with env-var
+  and dict-based configuration.
+- S3 support in Parquet data loading, output writing, image embedding,
+  and visual features processors.
+- `region` parameter for providers like OVH S3.
+
+### Documentation
+
+- Restructured docs: `docs/configuration/*.md`, metrics documentation,
+  formal concepts page.
+- New scenario example configs and example notebooks for each metric.
+- Updated user guide with installation, metrics, configuration, and usage.
+- Google-format docstrings across source packages.
+
+### Testing
+
+- New integration tests: batch invariance, pipeline ordering, path prefix,
+  output columns, data flow, full story, features embeddings.
+- New unit tests: matching, registry, representativeness, error policy,
+  output configs, job, pandas loader, domain gap processor.
+- New property-based tests: diversity, domain gap, representativeness,
+  visual features.
+- Package isolation smoke tests for all 5 packages.
+- Configurable test seeds via `DQM_ML_TEST_SEED` env var (default 42).
+- tqdm output suppressed in CI environments.
+- Synthetic data generated at runtime, replacing LFS-tracked files.
+
+### Python Compatibility
+
+- Python 3.10, 3.11, 3.12, 3.13 supported.
+
+### Breaking Changes
+
+- Package renamed: `dqm-ml-v2` → `dqm-ml`
+- CLI command: `dqm-ml-v2` → `dqm-ml`

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -6,17 +6,17 @@ DQM-ML pipelines are configured using **YAML** files. This guide explains how to
 
 ```mermaid
 flowchart TB
-    subgraph "config.yaml"
-        subgraph "features"
+    subgraph config["config.yaml"]
+        subgraph feat["features"]
             F1["outputs + processors"]
         end
-        subgraph "metrics"
+        subgraph met["metrics"]
             M1["outputs + processors"]
         end
-        subgraph "gap"
+        subgraph g["gap"]
             G1["outputs + processors"]
         end
-        subgraph "dataloaders"
+        subgraph dl["dataloaders"]
             DL1["loaders: [parquet, csv, ...]"]
         end
     end

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,6 +26,7 @@ You don't need to write code to contribute to DQM-ML!
 - 📝 **Examples & tutorials** - Add example scripts or notebooks showing DQM-ML usage
 - 🧪 **Better tests** - Make the project more robust
 - 🎨 **Website & docs design** - Improve mkdocs config, CSS, theme, documentation layout, mermaid diagrams
+- 📋 **Changelog** - Update CHANGELOG.md with your changes following the existing format
 
 ## Code Contribution Workflow
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -9,6 +9,15 @@
 
 The [Roadmap](./ROADMAP.md), do not hesitate to propose adjustments
 
+## Changelog
+
+For a detailed list of changes, see the [Changelog](./CHANGELOG.md).
+
+## Testing
+
+- [Testing Strategy](./testing.md) — Test organization, directory structure, and how to add new tests
+- [Packaging Tests](./packaging-tests.md) — Tests that validate package installation in isolated environments
+
 ## Packages documentations
 
 - [Core](./packages/dqm-ml-core.md)

--- a/docs/dqm-ml-overview.md
+++ b/docs/dqm-ml-overview.md
@@ -2,7 +2,11 @@
 
 This page is for developers who want to understand how DQM-ML is structured and how to work with the codebase. For a general introduction to what DQM-ML does, check out the [Home](index.md) page.
 
-> **See also:** [Concepts](formal_concepts.md) for definitions of **Metric**, **Batch Metric**, **Data Selection**, **Processor**, and related terminology used throughout this page.
+> **See also:** 
+
+> [Concepts](formal_concepts.md) for definitions of **Metric**, **Batch Metric**, **Data Selection**, **Processor**, and related terminology used throughout this page.
+
+> For the full developer guide, see [Developer Guide](developer.md).
 
 ## Package Architecture
 
@@ -27,10 +31,10 @@ Here's how the packages relate to each other:
 
 ```mermaid
 flowchart TB
-    job[dqm-ml-job<br/>Orchestration] --> core[dqm-ml-core<br/>Core API]
-    images[dqm-ml-images<br/>Visual Features] --> core
-    pytorch[dqm-ml-pytorch<br/>PyTorch Metrics] --> core
-    cli[dqm-ml<br/>CLI Wrapper] --> job
+    job[dqm-ml-job\nOrchestration] --> core[dqm-ml-core\nCore API]
+    images[dqm-ml-images\nVisual Features] --> core
+    pytorch[dqm-ml-pytorch\nPyTorch Metrics] --> core
+    cli[dqm-ml\nCLI Wrapper] --> job
     cli --> core
     cli --> images
     cli --> pytorch

--- a/docs/dqm-ml-v2.md
+++ b/docs/dqm-ml-v2.md
@@ -71,13 +71,6 @@ flowchart LR
         V2c["..."]
         V2agg["Aggregate all batch stats"]
     end
-    
-    style V1 fill:#ffcdd2
-    style V2a fill:#c8e6c9
-    style V2p1 fill:#c8e6c9
-    style V2b fill:#c8e6c9
-    style V2p2 fill:#c8e6c9
-    style V2c fill:#c8e6c9
 ```
 
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,163 +1,214 @@
 import re
-from pathlib import Path
 import shutil
+from pathlib import Path
 from urllib.parse import urljoin
 
 DOCS_INDEX = "docs/index.md"
+REPO_URL = "https://github.com/Safenai/dqm-ml-workspace"
 
 
-def update_readme_relative_links():
-    index = Path(DOCS_INDEX)
-    with index.open() as f:
-        md = f.read()
-        # Replace various forms of docs/ paths
-        updated_md = md.replace("./docs/", "./")
-        updated_md = updated_md.replace("(docs/", "(")
-        updated_md = updated_md.replace('src="docs/static/', 'src="./static/')
-        updated_md = updated_md.replace(
-            "(packages/",
-            "(https://github.com/Safenai/dqm-ml-workspace/tree/main/packages/",
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def _copy_if_changed(src: Path, dst: Path):
+    """Copy file only if destination doesn't exist or content differs.
+
+    Args:
+        src: Source file path.
+        dst: Destination file path.
+    """
+    if dst.exists() and dst.read_bytes() == src.read_bytes():
+        return
+    shutil.copy(src, dst)
+
+
+def _write_if_changed(dst: Path, content: str):
+    """Write text content to file only if it differs from existing content.
+
+    Args:
+        dst: Destination file path.
+        content: Text content to write.
+    """
+    if dst.exists() and dst.read_bytes() == content.encode():
+        return
+    dst.write_text(content)
+
+
+# ---------------------------------------------------------------------------
+# docs/index.md pipeline  (single pass — no ordering dependencies)
+# ---------------------------------------------------------------------------
+
+
+def _build_index():
+    """Copy README.md to docs/index.md, rewrite links for mkdocs site."""
+    content = Path("README.md").read_text()
+
+    # Rewrite relative paths that point into docs/ for GitHub/GitLab
+    content = content.replace("./docs/", "./")
+    content = content.replace("(docs/", "(")
+    content = content.replace('src="docs/static/', 'src="./static/')
+    content = content.replace(
+        "(packages/",
+        f"({REPO_URL}/tree/main/packages/",
+    )
+    content = content.replace(
+        "(examples/",
+        f"({REPO_URL}/tree/main/examples/",
+    )
+
+    # Inject repository link before "Available on PyPI" if not already present
+    repo_link = "- **[Repository](https://github.com/Safenai/dqm-ml-workspace)**"
+    if "## Available on PyPI" in content and repo_link not in content:
+        content = content.replace(
+            "## Available on PyPI",
+            f"{repo_link}\n\n## Available on PyPI",
         )
-        updated_md = updated_md.replace(
-            "(examples/",
-            "(https://github.com/Safenai/dqm-ml-workspace/tree/main/examples/",
-        )
-    with index.open("w") as f:
-        f.write(updated_md)
+
+    _write_if_changed(Path(DOCS_INDEX), content)
 
 
-def copy_examples():
+# ---------------------------------------------------------------------------
+# docs/examples/ pipeline  (single pass — copy + link fix in one go)
+# ---------------------------------------------------------------------------
+
+
+def _apply_example_link_fixes(content: str, depth: int) -> str:
+    """Rewrite relative links in example markdown based on destination depth.
+
+    Source files use ``../docs/...`` paths that work on GitHub. After copying
+    into ``docs/examples/``, the ``docs/`` prefix must be dropped.
+
+    Args:
+        content: Markdown content to transform.
+        depth: Directory depth in docs/examples/ (0 = root, 1 = subdirectory).
+
+    Returns:
+        Markdown content with relative links rewritten.
+    """
+    if depth == 0:
+        return content.replace("../docs/metrics/", "../metrics/")
+    elif depth == 1:
+        return content.replace("../../docs/metrics/", "../../metrics/")
+    return content
+
+
+def _copy_md_with_fixes(src: Path, dst: Path, depth: int):
+    """Copy a markdown file, applying link fixes in memory before writing.
+
+    Args:
+        src: Source markdown file path.
+        dst: Destination file path.
+        depth: Directory depth for link fix calculations.
+    """
+    content = _apply_example_link_fixes(src.read_text(), depth)
+    _write_if_changed(dst, content)
+
+
+def _sync_dir(src: Path, dst: Path, *, fix_md_links: bool = False):
+    """Sync a single directory by copying files to a destination.
+
+    Args:
+        src: Source directory path.
+        dst: Destination directory path.
+        fix_md_links: If True, apply link fixes when copying markdown files.
+    """
+    if not src.exists():
+        return
+    dst.mkdir(exist_ok=True)
+    for src_file in sorted(src.iterdir()):
+        if src_file.is_dir():
+            continue
+        dst_file = dst / src_file.name
+        if src_file.suffix == ".md" and fix_md_links:
+            _copy_md_with_fixes(src_file, dst_file, depth=0)
+        else:
+            _copy_if_changed(src_file, dst_file)
+
+
+def _build_examples():
+    """Copy examples/ to docs/examples/, rewriting .md links in one pass."""
     src_root = Path("examples")
     dst_root = Path("docs/examples")
     dst_root.mkdir(exist_ok=True)
 
-    # Copy overview.md from root
+    _sync_dir(src_root / "scenario", dst_root / "scenario", fix_md_links=True)
+    _sync_dir(src_root / "notebooks", dst_root / "notebooks")
+    _sync_dir(src_root / "config", dst_root / "config")
+    _sync_dir(src_root / "config" / "scenario", dst_root / "config" / "scenario")
+    _sync_dir(src_root / "script", dst_root / "script")
+
     overview = src_root / "overview.md"
     if overview.exists():
-        shutil.copy(overview, dst_root / "overview.md")
-
-    # Copy scenario markdowns
-    scenario_src = src_root / "scenario"
-    if scenario_src.exists():
-        scenario_dst = dst_root / "scenario"
-        scenario_dst.mkdir(exist_ok=True)
-        for md_file in scenario_src.glob("*.md"):
-            shutil.copy(md_file, scenario_dst / md_file.name)
-
-    # Copy notebooks
-    notebooks_src = src_root / "notebooks"
-    if notebooks_src.exists():
-        notebooks_dst = dst_root / "notebooks"
-        notebooks_dst.mkdir(exist_ok=True)
-        for nb_file in notebooks_src.glob("*.ipynb"):
-            shutil.copy(nb_file, notebooks_dst / nb_file.name)
-
-    # Copy configs
-    config_dst = dst_root / "config"
-    config_dst.mkdir(exist_ok=True)
-    for yaml_file in (src_root / "config").glob("*.yaml"):
-        shutil.copy(yaml_file, config_dst / yaml_file.name)
-
-    # Copy configs
-    config_dst = dst_root / "config/scenario"
-    config_dst.mkdir(exist_ok=True)
-    for yaml_file in (src_root / "config/scenario").glob("*.yaml"):
-        shutil.copy(yaml_file, config_dst / yaml_file.name)
-
-    # Copy scripts
-    script_dst = dst_root / "script"
-    script_dst.mkdir(exist_ok=True)
-    shutil.copy(
-        src_root / "script" / "completeness.py",
-        script_dst / "completeness.py",
-    )
+        _copy_md_with_fixes(overview, dst_root / "overview.md", depth=0)
 
 
-def copy_readme():
-    shutil.copy("README.md", DOCS_INDEX)
+# ---------------------------------------------------------------------------
+# Simple file copies  (source root → docs/)
+# ---------------------------------------------------------------------------
+
+
+def copy_changelog():
+    """Copy CHANGELOG.md from repo root to docs/."""
+    src = Path("CHANGELOG.md")
+    if src.exists():
+        _copy_if_changed(src, Path("docs/CHANGELOG.md"))
+
+
+def copy_release_notes():
+    """Copy RELEASE.md from repo root to docs/."""
+    src = Path("RELEASE.md")
+    if src.exists():
+        _copy_if_changed(src, Path("docs/RELEASE.md"))
 
 
 def copy_package_readmes():
-    """Copy package READMEs to docs/packages/ for documentation."""
+    """Copy package READMEs to docs/packages/."""
     packages_dir = Path("packages")
     docs_packages_dir = Path("docs/packages")
     docs_packages_dir.mkdir(exist_ok=True)
 
-    packages_to_copy = [
+    for pkg in [
         "dqm-ml-core",
         "dqm-ml-job",
         "dqm-ml-images",
         "dqm-ml-pytorch",
         "dqm-ml",
-    ]
-
-    for pkg in packages_to_copy:
+    ]:
         src = packages_dir / pkg / "README.md"
         if src.exists():
-            dst = docs_packages_dir / f"{pkg}.md"
-            shutil.copy(src, dst)
+            _copy_if_changed(src, docs_packages_dir / f"{pkg}.md")
 
 
-def rename_coverage_index():
+def _copy_coverage_report():
+    """Copy coverage index.html to coverage_report.html for direct linking."""
     coverage_index = Path("docs/reports/htmlcov/index.html")
     if coverage_index.exists():
-        shutil.copy(
-            "docs/reports/htmlcov/index.html",
-            "docs/reports/htmlcov/coverage_report.html",
-        )
+        _copy_if_changed(coverage_index, Path("docs/reports/htmlcov/coverage_report.html"))
 
 
-def add_repository_link():
-    """Add repository link before Available on PyPI section."""
-    index = Path(DOCS_INDEX)
-    with index.open() as f:
-        md = f.read()
-
-    repository_link = "- **[Repository](https://github.com/Safenai/dqm-ml-workspace)**"
-
-    if "## Available on PyPI" in md and repository_link not in md:
-        updated_md = md.replace("## Available on PyPI", f"{repository_link}\n\n## Available on PyPI")
-        with index.open("w") as f:
-            f.write(updated_md)
-
-
-def fix_example_links():
-    """Rewrite relative links in copied examples so they work under docs/examples/.
-
-    Source examples/ files use ../docs/... or ../../docs/... links that work
-    locally and on GitHub/GitLab. After being copied to docs/examples/, the
-    links need adjusting based on directory depth:
-      - docs/examples/ (depth 0):  ../docs/metrics/  -> ../metrics/
-      - docs/examples/scenario/ (depth 1): ../../docs/metrics/ -> ../../metrics/
-    """
-    examples_dir = Path("docs/examples")
-    for md_file in examples_dir.rglob("*.md"):
-        rel = md_file.relative_to(examples_dir)
-        depth = len(rel.parent.parts)
-
-        with md_file.open() as f:
-            md = f.read()
-
-        if depth == 0:
-            updated_md = md.replace("../docs/metrics/", "../metrics/")
-        elif depth == 1:
-            updated_md = md.replace("../../docs/metrics/", "../../metrics/")
-        else:
-            updated_md = md
-
-        if updated_md != md:
-            with md_file.open("w") as f:
-                f.write(updated_md)
+# ---------------------------------------------------------------------------
+# mkdocs page_markdown hook  (per-page, during render)
+# ---------------------------------------------------------------------------
 
 
 def _transform_examples_to_github(markdown: str, src_path: str) -> str:
     """Transform relative links to examples/ into GitHub URLs.
 
-    Source docs/*.md files use relative paths like ../examples/... that work
-    locally and on GitHub/GitLab. On the mkdocs website these example files
-    aren't served directly, so rewrite the links to permanent GitHub URLs.
+    Source docs/*.md files use relative paths like ``../examples/...`` that
+    work locally and on GitHub/GitLab. On the mkdocs website these example
+    files aren't served directly, so rewrite the links to permanent GitHub
+    URLs.
+
+    Args:
+        markdown: Raw markdown content.
+        src_path: Source path of the page relative to docs/.
+
+    Returns:
+        Markdown content with example links rewritten to GitHub URLs.
     """
-    github_raw = "https://github.com/Safenai/dqm-ml-workspace/tree/main"
+    github_raw = f"{REPO_URL}/tree/main"
 
     if src_path.startswith("examples/"):
         page_dir = src_path.rsplit("/", 1)[0] + "/"
@@ -173,49 +224,72 @@ def _transform_examples_to_github(markdown: str, src_path: str) -> str:
                 return f"[{text}]({github_raw}/{resolved})"
             return m.group(0)
 
-        markdown = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _repl, markdown)
-        return markdown
+        return re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _repl, markdown)
 
     # src_path is relative to docs/ directory.
     # E.g., "cli.md" → depth 0 → need "../" to reach repo root
     #        "configuration/features.md" → depth 1 → need "../../"
     depth = src_path.count("/")
     prefix = "../" * (depth + 1)
-    markdown = markdown.replace(f"({prefix}examples/", f"({github_raw}/examples/")
-
-    return markdown
+    return markdown.replace(f"({prefix}examples/", f"({github_raw}/examples/")
 
 
 def _transform_package_links(markdown: str, src_path: str) -> str:
-    """Transform relative links to packages/*/README.md into docs/packages/*.md links.
+    """Transform relative package README links into docs/ page links.
 
-    Source docs/*.md files use ../packages/xxx/README.md paths that work locally
-    and on GitHub/GitLab. On the mkdocs website these READMEs have been copied to
-    docs/packages/xxx.md, so rewrite the links accordingly.
+    Source docs/*.md files use ``../packages/xxx/README.md`` paths that work
+    on GitHub. On the mkdocs website these READMEs have been copied to
+    ``docs/packages/xxx.md``, so rewrite the links accordingly.
+
+    Args:
+        markdown: Raw markdown content.
+        src_path: Source path of the page relative to docs/.
+
+    Returns:
+        Markdown content with package links rewritten.
     """
+
     if src_path.startswith("examples/"):
         return markdown
 
-    markdown = re.sub(
+    return re.sub(
         r"\(\.\./packages/([^/]+)/README\.md(#[^)]*)?\)",
         r"(packages/\1.md\2)",
         markdown,
     )
-    return markdown
 
 
 def page_markdown(markdown, page, config, files):  # NOSONAR
-    """Hook: transform relative links after page markdown is loaded."""
+    """Transform relative links after page markdown is loaded.
+
+    Args:
+        markdown: Raw markdown content of the page.
+        page: MkDocs page object.
+        config: MkDocs configuration.
+        files: Collection of all files in the docs directory.
+
+    Returns:
+        Transformed markdown content.
+    """
     markdown = _transform_examples_to_github(markdown, page.file.src_path)
     markdown = _transform_package_links(markdown, page.file.src_path)
     return markdown
 
 
+# ---------------------------------------------------------------------------
+# mkdocs pre_build hook  (runs once before every build)
+# ---------------------------------------------------------------------------
+
+
 def pre_build(*args, **kwargs):
-    copy_examples()
-    fix_example_links()
-    copy_readme()
-    add_repository_link()
+    """Pre-build hook: copy and transform files for mkdocs.
+
+    All functions are self-contained — no implicit ordering dependencies.
+    Each uses content-aware writes to avoid triggering unnecessary rebuilds.
+    """
+    copy_changelog()
+    copy_release_notes()
     copy_package_readmes()
-    rename_coverage_index()
-    update_readme_relative_links()
+    _copy_coverage_report()
+    _build_index()
+    _build_examples()

--- a/docs/packaging-tests.md
+++ b/docs/packaging-tests.md
@@ -163,8 +163,8 @@ flowchart LR
     B --> C[dev branch]
     C --> D[main branch]
 
-    A -.- A1["Build wheels<br>test locally"]
-    B -.- B1["CI runs<br>unit/int tests"]
+    A -.- A1["Build wheels\n test locally"]
+    B -.- B1["CI runs\n unit/int tests"]
     C -.- C1["test.pypi.org"]
     D -.- D1["pypi.org"]
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,8 @@ Get up and running with DQM-ML in minutes.
 
 > **See also:** [Concepts](formal_concepts.md) for definitions of **Sample**, **Metric**, **Processor**, and related terminology used throughout this page.
 
+> **What's new?** See the [Release Notes](./RELEASE.md) for the latest features and improvements.
+
 ## Installation
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,18 +9,18 @@ flowchart TB
 
     subgraph "Test Types"
   
-        U[Unit Tests<br/>tests/unit]
-        I[Integration Tests<br/>tests/integration]
-        C[CLI Tests<br/>tests/cli]
-        P[Packaging Tests<br/>tests/packaging]
-        B[Benchmark Tests<br/>tests/benchmark]
+        U[Unit Tests\n tests/unit]
+        I[Integration Tests\n tests/integration]
+        C[CLI Tests\n tests/cli]
+        P[Packaging Tests\n tests/packaging]
+        B[Benchmark Tests\n tests/benchmark]
     end
     
     subgraph "Test Pyramid"
-        TP[Unit Tests - Fast, isolated<br/>Core logic, processors]
-        TI[Integration Tests - Real data<br/>Pipelines, loaders, metrics]
-        TC[CLI Tests - End-to-end<br/>Commands, config files]
-        PP[Packaging Tests - Isolated venvs<br/>Package installation scenarios]
+        TP[Unit Tests - Fast, isolated\n Core logic, processors]
+        TI[Integration Tests - Real data\n Pipelines, loaders, metrics]
+        TC[CLI Tests - End-to-end\n Commands, config files]
+        PP[Packaging Tests - Isolated venvs\n Package installation scenarios]
     end
     
     U --> TP
@@ -28,12 +28,12 @@ flowchart TB
     C --> TC
     P --> PP
 
-    F[Fixtures - Shared test data<br/>tests/fixtures/ and tests/integration/fixtures/]
+    F[Fixtures - Shared test data\n tests/fixtures/ and tests/integration/fixtures/]
     TP --> F
     TI --> F
     B --> F
 
-    B -.-> BN[Compares v1 IRT-SystemX/dqm-ml<br/>and v2 this repo metric values<br/>on open-source datasets]
+    B -.-> BN[Compares v1 IRT-SystemX/dqm-ml\n and v2 this repo metric values\n on open-source datasets]
 ```
 
 ## Test Directory Structure

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,11 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets:
       check_paths: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom
   - pymdownx.tabbed:
       alternate_style: true
       slugify: !!python/object/apply:pymdownx.slugs.slugify
@@ -93,6 +97,9 @@ plugins:
       enabled: !ENV [MKDOCS_MATERIAL_OFFLINE, false]
   - mermaid2:
       version: 11.16.0
+      arguments:
+        securityLevel: loose
+        htmlLabels: false
   - mkdocstrings:
       handlers:
         python:
@@ -149,7 +156,8 @@ nav:
       - Data Selection: configuration/data_selection.md
       - Global: configuration/global.md
       - JSON Schema: schema/schema.md
-    - YAML Basics: yaml_basics.md
+      - YAML Basics: yaml_basics.md
+    - Release Notes: RELEASE.md
   - Metrics: 
     - Overview: metrics.md
     - Completeness : metrics/completeness.md
@@ -184,6 +192,7 @@ nav:
     - Testing: testing.md
     - Packaging Tests: packaging-tests.md
     - Roadmap: ROADMAP.md
+    - Changelog: CHANGELOG.md
     - Packages:
       - Core: packages/dqm-ml-core.md
       - Job: packages/dqm-ml-job.md


### PR DESCRIPTION
- Add RELEASE.md (user release notes for v2.0.0)
- Add CHANGELOG.md with 2.0.0-rc4 entry (technical changelog)
- Wire both into mkdocs navigation (Release Notes + Changelog)
- Update docs/hooks.py: single-pass copy+transform for index and examples
- Fix mermaid diagrams: replace <br/> with \n for line breaks
- Fix dark mode mermaid: remove hardcoded styles from dqm-ml-v2.md
- Fix mkdocs.yml: add htmlLabels, custom_fences for mermaid2 plugin
- Add cross-references: README, quickstart, contributing, developer pages
- Add developer.md Testing section referencing testing.md and packaging-tests.md